### PR TITLE
Initialize React project skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,21 @@
 # Paty
-application paty
+
+A React-based fitness coaching application.
+
+This repository contains a minimal React + Vite setup for the iPaty project.
+
+## Getting Started
+
+Install dependencies (requires network access):
+
+```bash
+npm install
+```
+
+Run the development server:
+
+```bash
+npm run dev
+```
+
+A future update will integrate Capacitor for mobile builds (iOS and Android).

--- a/app/index.html
+++ b/app/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>iPaty</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/app/package.json
+++ b/app/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "ipaty",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.23.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.0",
+    "@types/react-dom": "^18.2.0",
+    "typescript": "^5.3.3",
+    "vite": "^5.0.0",
+    "@vitejs/plugin-react": "^4.0.0"
+  }
+}

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { BrowserRouter, Routes, Route } from 'react-router-dom';
+import LandingPage from './pages/LandingPage';
+import SubscriptionPage from './pages/SubscriptionPage';
+import Dashboard from './pages/Dashboard';
+
+const App: React.FC = () => {
+  return (
+    <BrowserRouter>
+      <Routes>
+        <Route path="/" element={<LandingPage />} />
+        <Route path="/subscribe" element={<SubscriptionPage />} />
+        <Route path="/dashboard" element={<Dashboard />} />
+      </Routes>
+    </BrowserRouter>
+  );
+};
+
+export default App;

--- a/app/src/main.tsx
+++ b/app/src/main.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/app/src/pages/Dashboard.tsx
+++ b/app/src/pages/Dashboard.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+
+const Dashboard: React.FC = () => {
+  return (
+    <section>
+      <h2>Mon Programme</h2>
+      <p>Progression et programmes à afficher ici.</p>
+      {/* TODO: Show training and nutrition plans */}
+    </section>
+  );
+};
+
+export default Dashboard;

--- a/app/src/pages/HealthQuestionnaire.tsx
+++ b/app/src/pages/HealthQuestionnaire.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+
+const HealthQuestionnaire: React.FC = () => {
+  return (
+    <section>
+      <h2>Questionnaire Santé</h2>
+      <p>Ce formulaire doit être complété lors de l'inscription.</p>
+      {/* TODO: Add form fields */}
+    </section>
+  );
+};
+
+export default HealthQuestionnaire;

--- a/app/src/pages/LandingPage.tsx
+++ b/app/src/pages/LandingPage.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+
+const LandingPage: React.FC = () => {
+  return (
+    <main>
+      <h1>Bienvenue sur iPaty</h1>
+      <p>Choisissez votre formule d'entraînement et commencez dès aujourd'hui.</p>
+      {/* TODO: Add subscription buttons linked with Stripe */}
+    </main>
+  );
+};
+
+export default LandingPage;

--- a/app/src/pages/SubscriptionPage.tsx
+++ b/app/src/pages/SubscriptionPage.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+
+const SubscriptionPage: React.FC = () => {
+  return (
+    <section>
+      <h2>Souscription</h2>
+      <p>Intégration Stripe à venir.</p>
+      {/* TODO: Implement Stripe checkout form */}
+    </section>
+  );
+};
+
+export default SubscriptionPage;

--- a/app/tsconfig.json
+++ b/app/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "strict": true,
+    "jsx": "react-jsx",
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/app/tsconfig.node.json
+++ b/app/tsconfig.node.json
@@ -1,0 +1,8 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "CommonJS",
+    "esModuleInterop": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/app/vite.config.ts
+++ b/app/vite.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 3000,
+  },
+});


### PR DESCRIPTION
## Summary
- create React/Vite project structure under `app`
- add basic routing with React Router
- include placeholder pages for landing, subscription, dashboard, and health questionnaire
- document setup steps in README

## Testing
- `npm run build` *(fails: vite not found because dependencies are not installed)*