### PR TITLE
Add admin dashboard

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -3,6 +3,7 @@ import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import LandingPage from './pages/LandingPage';
 import SubscriptionPage from './pages/SubscriptionPage';
 import Dashboard from './pages/Dashboard';
+import AdminDashboard from './pages/AdminDashboard';
 import NavBar from './components/NavBar';
 import HealthQuestionnaire from './pages/HealthQuestionnaire';
 import LoginPage from './pages/LoginPage';
@@ -25,6 +26,14 @@ const App: React.FC = () => {
             element={
               <PrivateRoute>
                 <Dashboard />
+              </PrivateRoute>
+            }
+          />
+          <Route
+            path="/admin"
+            element={
+              <PrivateRoute>
+                <AdminDashboard />
               </PrivateRoute>
             }
           />

--- a/app/src/pages/AdminDashboard.tsx
+++ b/app/src/pages/AdminDashboard.tsx
@@ -1,0 +1,27 @@
+import React, { useState } from 'react';
+
+const AdminDashboard: React.FC = () => {
+  const [video, setVideo] = useState<File | null>(null);
+  const [title, setTitle] = useState('');
+  const [description, setDescription] = useState('');
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    // TODO: implement upload logic
+    console.log({ video, title, description });
+  };
+
+  return (
+    <main className="container" style={{ maxWidth: '600px' }}>
+      <h1>Ajouter une vidéo</h1>
+      <form onSubmit={handleSubmit} style={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}>
+        <input type="file" accept="video/*" onChange={e => setVideo(e.target.files ? e.target.files[0] : null)} />
+        <input type="text" placeholder="Titre" value={title} onChange={e => setTitle(e.target.value)} />
+        <textarea placeholder="Description" value={description} onChange={e => setDescription(e.target.value)} rows={4} />
+        <button type="submit" className="btn">Envoyer</button>
+      </form>
+    </main>
+  );
+};
+
+export default AdminDashboard;


### PR DESCRIPTION
## Summary
- build an `AdminDashboard` page with a simple upload form
- create a new `/admin` route protected by `PrivateRoute`

## Testing
- `npm run build` *(fails: vite missing)*