### PR TITLE
Update README with admin instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,16 @@ Lancez le serveur de développement :
 npm run dev
 ```
 
+### Démarrer la page d'administration
+
+Une interface d'administration est disponible pour gérer le contenu de l'application.
+Depuis le dossier `app`, lancez le serveur local et accédez ensuite à `http://localhost:5173/admin` :
+
+```bash
+cd app
+npm run dev
+```
+
 ### Démarrer le serveur Stripe
 
 Un petit serveur Express est fourni pour la création des sessions de paiement. Configurez votre clé secrète Stripe dans la variable `STRIPE_SECRET_KEY` puis lancez :
@@ -26,6 +36,26 @@ Un petit serveur Express est fourni pour la création des sessions de paiement. 
 cd server && npm install
 npm start
 ```
+
+### Variables d'environnement CDN
+
+L'application peut envoyer des fichiers vers un CDN. Configurez les variables suivantes dans un fichier `.env` :
+
+- `CDN_BASE_URL` : URL du service CDN
+- `CDN_API_KEY` : clé d'authentification
+
+Ces valeurs seront utilisées par le serveur lors des opérations d'upload.
+
+### Lancer l'endpoint d'upload
+
+Un endpoint `/upload` est exposé par le serveur pour transférer des fichiers vers le CDN. Après avoir défini les variables d'environnement ci-dessus :
+
+```bash
+cd server
+npm start
+```
+
+Vous pouvez ensuite envoyer vos fichiers via une requête HTTP POST sur `http://localhost:4242/upload`.
 
 ### Builds mobiles Capacitor
 


### PR DESCRIPTION
## Summary
- explain how to start the admin page
- document CDN environment variables
- add notes on the upload endpoint

## Testing
- `npm test` *(fails: Could not read package.json)*