### PR TITLE
Use env vars for Stripe keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,23 @@ cd server && npm install
 npm start
 ```
 
+### Variables d'environnement Stripe
+
+Définissez les clés et identifiants de prix nécessaires dans `server/.env` :
+
+```bash
+STRIPE_SECRET_KEY=your_secret_key
+STRIPE_BASIC_PRICE_ID=price_for_basic
+STRIPE_PREMIUM_PRICE_ID=price_for_premium
+STRIPE_ANNUAL_PRICE_ID=price_for_annual
+```
+
+Pour le client React, créez également un fichier `app/.env` avec :
+
+```bash
+VITE_STRIPE_PUBLIC_KEY=pk_test_your_public_key
+```
+
 
 ### Variables d'environnement CDN
 

--- a/app/src/pages/SubscriptionPage.tsx
+++ b/app/src/pages/SubscriptionPage.tsx
@@ -8,7 +8,7 @@ const SubscriptionPage: React.FC = () => {
   const [selectedPlan, setSelectedPlan] = useState<Plan>('premium');
 
   const handleCheckout = async () => {
-    const stripe = await loadStripe('pk_test_placeholder');
+    const stripe = await loadStripe(import.meta.env.VITE_STRIPE_PUBLIC_KEY);
     try {
       const response = await fetch('http://localhost:4242/create-checkout-session', {
         method: 'POST',

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -22,9 +22,9 @@ const stripe = new Stripe(stripeSecretKey, {
 });
 
 const PRICE_IDS = {
-  basic: 'price_basic', // TODO: replace with real Stripe price ID
-  premium: 'price_premium',
-  annual: 'price_annual'
+  basic: process.env.STRIPE_BASIC_PRICE_ID,
+  premium: process.env.STRIPE_PREMIUM_PRICE_ID,
+  annual: process.env.STRIPE_ANNUAL_PRICE_ID
 };
 
 app.post('/create-checkout-session', async (req, res) => {


### PR DESCRIPTION
## Summary
- read Stripe public key from Vite env in SubscriptionPage
- configure server to use env variables for price IDs
- document required Stripe variables in README

## Testing
- `npm test` *(fails: ENOENT because no root package.json)*
- `cd app && npm test` *(fails: Missing script `test`)*
- `cd server && npm test` *(fails: Missing script `test`)*