### PR TITLE
Add user level context

### DIFF
--- a/app/src/context/AuthContext.tsx
+++ b/app/src/context/AuthContext.tsx
@@ -1,8 +1,11 @@
 import React, { useState, createContext, ReactNode } from 'react';
+import { Level } from './Level';
 
 interface AuthContextProps {
   isAuthenticated: boolean;
   twoFACode: string | null;
+  level: Level;
+  setLevel: (level: Level) => void;
   login: (username: string, password: string) => string | null;
   verifyCode: (code: string) => boolean;
   logout: () => void;
@@ -13,6 +16,7 @@ export const AuthContext = createContext<AuthContextProps | undefined>(undefined
 export const AuthProvider = ({ children }: { children: ReactNode }) => {
   const [isAuthenticated, setIsAuthenticated] = useState(false);
   const [twoFACode, setTwoFACode] = useState<string | null>(null);
+  const [level, setLevel] = useState<Level>(Level.LEVEL1);
 
   const login = (username: string, password: string) => {
     // Very basic credential check, for demo purposes
@@ -39,7 +43,7 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
   };
 
   return (
-    <AuthContext.Provider value={{ isAuthenticated, twoFACode, login, verifyCode, logout }}>
+    <AuthContext.Provider value={{ isAuthenticated, twoFACode, level, setLevel, login, verifyCode, logout }}>
       {children}
     </AuthContext.Provider>
   );

--- a/app/src/context/Level.ts
+++ b/app/src/context/Level.ts
@@ -1,0 +1,17 @@
+export enum Level {
+  LEVEL1 = 'level1',
+  LEVEL2 = 'level2',
+  LEVEL3 = 'level3',
+  LEVEL4 = 'level4',
+  LEVEL5 = 'level5',
+  LEVEL6 = 'level6'
+}
+
+export const LEVEL_LABELS: Record<Level, string> = {
+  [Level.LEVEL1]: 'Niveau 1',
+  [Level.LEVEL2]: 'Niveau 2',
+  [Level.LEVEL3]: 'Niveau 3',
+  [Level.LEVEL4]: 'Niveau 4',
+  [Level.LEVEL5]: 'Niveau 5',
+  [Level.LEVEL6]: 'Niveau 6'
+};

--- a/app/src/pages/Dashboard.tsx
+++ b/app/src/pages/Dashboard.tsx
@@ -1,9 +1,15 @@
-import React from 'react';
+import React, { useContext } from 'react';
+import { AuthContext } from '../context/AuthContext';
+import { LEVEL_LABELS } from '../context/Level';
 
 const Dashboard: React.FC = () => {
+  const auth = useContext(AuthContext);
+  if (!auth) return null;
+
   return (
     <main className="container">
       <h1 className="text-gradient">Mon tableau de bord</h1>
+      <p style={{ marginBottom: '1rem' }}>Niveau: {LEVEL_LABELS[auth.level]}</p>
       
       <div style={{ display: 'flex', flexWrap: 'wrap', gap: '2rem', marginBottom: '2rem' }}>
         <div style={{ flex: '1 1 300px', background: 'white', borderRadius: '1rem', padding: '1.5rem', boxShadow: 'var(--shadow-md)' }}>

--- a/app/src/pages/HealthQuestionnaire.tsx
+++ b/app/src/pages/HealthQuestionnaire.tsx
@@ -1,7 +1,14 @@
-import React from 'react';
+import React, { useContext, useState } from 'react';
 import { Link } from 'react-router-dom';
+import { AuthContext } from '../context/AuthContext';
+import { Level, LEVEL_LABELS } from '../context/Level';
 
 const HealthQuestionnaire: React.FC = () => {
+  const auth = useContext(AuthContext);
+  const [userLevel, setUserLevel] = useState<Level>(auth?.level ?? Level.LEVEL1);
+
+  if (!auth) return null;
+
   return (
     <main className="container">
       <h1>Questionnaire de Santé</h1>
@@ -22,6 +29,23 @@ const HealthQuestionnaire: React.FC = () => {
           <div className="form-group">
             <label htmlFor="weight">Poids (kg):</label>
             <input id="weight" type="number" min="30" max="300" placeholder="Votre poids en kg" required />
+          </div>
+
+          <div className="form-group">
+            <label htmlFor="level">Votre niveau:</label>
+            <select
+              id="level"
+              value={userLevel}
+              onChange={e => {
+                const lvl = e.target.value as Level;
+                setUserLevel(lvl);
+                auth.setLevel(lvl);
+              }}
+            >
+              {Object.values(Level).map(l => (
+                <option key={l} value={l}>{LEVEL_LABELS[l]}</option>
+              ))}
+            </select>
           </div>
           
           <div className="form-group">


### PR DESCRIPTION
## Summary
- store user level in context and expose setter
- add Level enum with six basic levels
- select user level in the health questionnaire
- show the chosen level on the dashboard

## Testing
- `node node_modules/vite/bin/vite.js build` *(fails: Cannot find module '@rollup/rollup-linux-x64-gnu')*