### PR TITLE
Use env checkout urls

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,13 +39,17 @@ npm start
 
 ### Variables d'environnement Stripe
 
-Définissez les clés et identifiants de prix nécessaires dans `server/.env` :
+Définissez les clés et identifiants de prix nécessaires dans `server/.env` (un fichier `server/.env.example` est fourni) :
 
 ```bash
 STRIPE_SECRET_KEY=your_secret_key
 STRIPE_BASIC_PRICE_ID=price_for_basic
 STRIPE_PREMIUM_PRICE_ID=price_for_premium
 STRIPE_ANNUAL_PRICE_ID=price_for_annual
+SUCCESS_URL=http://localhost:5173/dashboard?session_id={CHECKOUT_SESSION_ID}
+CANCEL_URL=http://localhost:5173/subscribe
+# facultatif : utiliser CLIENT_BASE_URL pour dériver les deux URL
+CLIENT_BASE_URL=http://localhost:5173
 ```
 
 Pour le client React, créez également un fichier `app/.env` avec :

--- a/server/.env.example
+++ b/server/.env.example
@@ -1,0 +1,22 @@
+# Exemple de configuration pour le serveur Express
+# Copiez ce fichier en .env et remplissez les valeurs
+
+# Port d'ecoute (optionnel)
+PORT=4242
+
+# Identifiants Stripe
+STRIPE_SECRET_KEY=
+STRIPE_BASIC_PRICE_ID=
+STRIPE_PREMIUM_PRICE_ID=
+STRIPE_ANNUAL_PRICE_ID=
+
+# URL de redirection apr�s paiement
+SUCCESS_URL=http://localhost:5173/dashboard?session_id={CHECKOUT_SESSION_ID}
+CANCEL_URL=http://localhost:5173/subscribe
+# Ou définissez CLIENT_BASE_URL pour dériver les URL ci-dessus
+CLIENT_BASE_URL=http://localhost:5173
+
+# Crédentials Cloudinary pour l'upload de vidéos
+CLOUDINARY_CLOUD_NAME=
+CLOUDINARY_API_KEY=
+CLOUDINARY_API_SECRET=

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -40,8 +40,10 @@ app.post('/create-checkout-session', async (req, res) => {
       line_items: [
         { price: priceId, quantity: 1 }
       ],
-      success_url: 'http://localhost:5173/dashboard?session_id={CHECKOUT_SESSION_ID}',
-      cancel_url: 'http://localhost:5173/subscribe'
+      success_url: process.env.SUCCESS_URL ||
+        `${process.env.CLIENT_BASE_URL || 'http://localhost:5173'}/dashboard?session_id={CHECKOUT_SESSION_ID}`,
+      cancel_url: process.env.CANCEL_URL ||
+        `${process.env.CLIENT_BASE_URL || 'http://localhost:5173'}/subscribe`
     });
     res.json({ id: session.id });
   } catch (err) {


### PR DESCRIPTION
## Summary
- configure checkout URLs from environment variables
- add sample env file for the server
- document `SUCCESS_URL` and `CANCEL_URL`

## Testing
- `npm test` *(fails: Missing script)*